### PR TITLE
Prepare for release v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20201105074044-be7a1044891a
 	kmodules.xyz/objectstore-api v0.0.0-20210218144135-bfabb80e0362
 	kmodules.xyz/offshoot-api v0.0.0-20210308072215-581e7685cd02
-	kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53
+	kubedb.dev/apimachinery v0.18.0
 	sigs.k8s.io/yaml v1.2.0
 	stash.appscode.dev/apimachinery v0.12.1
 	xorm.io/xorm v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1572,8 +1572,8 @@ kmodules.xyz/openshift v0.0.0-20201105073146-0da509a7d39f/go.mod h1:vFwB/f5rVH5Q
 kmodules.xyz/prober v0.0.0-20210218144026-43e923722d81 h1:mi0XHhavbXQqj9q89dNhWaOdGjZWHhpr3ai5gSYMZ44=
 kmodules.xyz/prober v0.0.0-20210218144026-43e923722d81/go.mod h1:2eN8X5Wq7/AAgE5AWMAX8T0lE51HZiYEldG2RQuouX4=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
-kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53 h1:qInWcSGHqgjUsI/phQAR97T5WgoLL4BqsaI5waa1JVk=
-kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53/go.mod h1:Z40oGFQbjQJoa7WzhJrOJDgEOian5YzQJdol0bFs1Sg=
+kubedb.dev/apimachinery v0.18.0 h1:Ar4qup7opGzzKENZeidgi6fQHmLqhTsVkbok+TJxDOo=
+kubedb.dev/apimachinery v0.18.0/go.mod h1:Z40oGFQbjQJoa7WzhJrOJDgEOian5YzQJdol0bFs1Sg=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -771,7 +771,7 @@ kmodules.xyz/objectstore-api/api/v1
 kmodules.xyz/offshoot-api/api/v1
 # kmodules.xyz/prober v0.0.0-20210218144026-43e923722d81
 kmodules.xyz/prober/api/v1
-# kubedb.dev/apimachinery v0.17.2-0.20210415110305-fdf2681b7c53
+# kubedb.dev/apimachinery v0.18.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.04.16
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/37
Signed-off-by: 1gtm <1gtm@appscode.com>